### PR TITLE
Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ repository = "https://github.com/briansmith/ring"
 rust-version = "1.61.0"
 
 # Keep in sync with `links` below.
-version = "0.17.8"
+version = "0.16.20"
 
 # Keep in sync with `version` above.
 #
 # build.rs verifies that this equals "ring_core_{major}_{minor}_{patch}_{pre}"
 # as keeping this in sync with the symbol prefixing is crucial for ensuring
 # the safety of multiple versions of *ring* being used in a program.
-links = "ring_core_0_17_8_"
+links = "ring_core_0_16_20_"
 
 include = [
     "LICENSE",


### PR DESCRIPTION
Update the version in the Cargo toml so it can be used to patch riscv support into other crates